### PR TITLE
feat: matching of path to destination on nav components fixed

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -188,7 +188,72 @@ declare module 'astro:content' {
 	>;
 
 	type ContentEntryMap = {
-		
+		"events": {
+"2023-03-18-symposium.md": {
+	id: "2023-03-18-symposium.md";
+  slug: "2023-03-18-symposium";
+  body: string;
+  collection: "events";
+  data: InferEntrySchema<"events">
+} & { render(): Render[".md"] };
+"2023-04-11-tyndall-stone-presentation.md": {
+	id: "2023-04-11-tyndall-stone-presentation.md";
+  slug: "2023-04-11-tyndall-stone-presentation";
+  body: string;
+  collection: "events";
+  data: InferEntrySchema<"events">
+} & { render(): Render[".md"] };
+"2023-04-21-monthlyMeeting.md": {
+	id: "2023-04-21-monthlyMeeting.md";
+  slug: "2023-04-21-monthlymeeting";
+  body: string;
+  collection: "events";
+  data: InferEntrySchema<"events">
+} & { render(): Render[".md"] };
+"2023-06-17-warner-field-trip.md": {
+	id: "2023-06-17-warner-field-trip.md";
+  slug: "2023-06-17-warner-field-trip";
+  body: string;
+  collection: "events";
+  data: InferEntrySchema<"events">
+} & { render(): Render[".md"] };
+"2023-07-08-kpg-boundary-field-trip.md": {
+	id: "2023-07-08-kpg-boundary-field-trip.md";
+  slug: "2023-07-08-kpg-boundary-field-trip";
+  body: string;
+  collection: "events";
+  data: InferEntrySchema<"events">
+} & { render(): Render[".md"] };
+"2023-07-14-green-river-field-trip.md": {
+	id: "2023-07-14-green-river-field-trip.md";
+  slug: "2023-07-14-green-river-field-trip";
+  body: string;
+  collection: "events";
+  data: InferEntrySchema<"events">
+} & { render(): Render[".md"] };
+"2023-08-19-danek-bonebed-field-trip.md": {
+	id: "2023-08-19-danek-bonebed-field-trip.md";
+  slug: "2023-08-19-danek-bonebed-field-trip";
+  body: string;
+  collection: "events";
+  data: InferEntrySchema<"events">
+} & { render(): Render[".md"] };
+"2023-09-15-monthlyMeeting.md": {
+	id: "2023-09-15-monthlyMeeting.md";
+  slug: "2023-09-15-monthlymeeting";
+  body: string;
+  collection: "events";
+  data: InferEntrySchema<"events">
+} & { render(): Render[".md"] };
+"2023-09-16-tyndall-stone-field-trip.md": {
+	id: "2023-09-16-tyndall-stone-field-trip.md";
+  slug: "2023-09-16-tyndall-stone-field-trip";
+  body: string;
+  collection: "events";
+  data: InferEntrySchema<"events">
+} & { render(): Render[".md"] };
+};
+
 	};
 
 	type DataEntryMap = {
@@ -197,5 +262,5 @@ declare module 'astro:content' {
 
 	type AnyEntryMap = ContentEntryMap & DataEntryMap;
 
-	type ContentConfig = never;
+	type ContentConfig = typeof import("../src/content/config");
 }

--- a/src/components/NavMenuDesktop.astro
+++ b/src/components/NavMenuDesktop.astro
@@ -1,11 +1,9 @@
 ---
 import { links, pathMatchesDestination } from "../utility";
 const pathName = new URL(Astro.request.url).pathname;
-const currentPath = pathName.replace(/\//g, "");
-console.log({ currentPath });
 
 const matchesDestination = (destination: string) => {
-	return pathMatchesDestination(currentPath, destination);
+	return pathMatchesDestination(pathName, destination);
 };
 ---
 
@@ -29,7 +27,16 @@ const matchesDestination = (destination: string) => {
 										label: subLabel,
 									}) => {
 										return (
-											<li class="nav-li-subheading">
+											<li
+												class={
+													"nav-li-subheading" +
+													(matchesDestination(
+														subDestination
+													)
+														? " active"
+														: "")
+												}
+											>
 												<a href={subDestination}>
 													{subLabel}
 												</a>

--- a/src/components/NavMenuMobile.astro
+++ b/src/components/NavMenuMobile.astro
@@ -1,16 +1,32 @@
 ---
-import { links } from "../utility";
+import { links, pathMatchesDestination } from "../utility";
+
+const path = new URL(Astro.request.url).pathname;
+const matchesDestination = (destination: string) => {
+	return pathMatchesDestination(path, destination);
+};
 ---
 
 <ul>
 	{
 		links.map(({ destination, label, subheadings }) => {
+			const classList = [];
+			if (subheadings) {
+				classList.push("subheadings-present");
+			}
 			return (
 				<details>
-					<summary
-						class:list={subheadings ? ["subheadings-present"] : []}
-					>
-						<a href={destination}>{label}</a>
+					<summary class:list={classList}>
+						<a
+							class:list={
+								matchesDestination(destination)
+									? ["active"]
+									: []
+							}
+							href={destination}
+						>
+							{label}
+						</a>
 					</summary>
 					{subheadings && (
 						<ul>
@@ -19,7 +35,13 @@ import { links } from "../utility";
 									destination: subDestination,
 									label: subLabel,
 								}) => (
-									<li>
+									<li
+										class:list={
+											matchesDestination(subDestination)
+												? ["active"]
+												: []
+										}
+									>
 										<a href={subDestination}>{subLabel}</a>
 									</li>
 								)
@@ -35,13 +57,12 @@ import { links } from "../utility";
 <style>
 	ul {
 		list-style-type: none;
-		margin-left: 12px;
+		margin-left: calc(3 * var(--theme-spacing-base));
 	}
 
 	/* Styling the summary / details view */
 	summary {
 		display: block;
-		/* margin: 8px; */
 	}
 
 	summary.subheadings-present::after {
@@ -62,8 +83,9 @@ import { links } from "../utility";
 	/* End summary / details view styling */
 
 	details a {
-		margin: 8px 4px;
-		padding: 0px 4px;
+		margin: calc(2 * var(--theme-spacing-base))
+			calc(1 * var(--theme-spacing-base));
+		padding: 0px var(--theme-spacing-base);
 		/* display: block; */
 		transition: background-color var(--transition-speed-medium);
 		border-radius: var(--border-radius-medium);
@@ -74,14 +96,22 @@ import { links } from "../utility";
 	}
 
 	details a:hover {
-		/* display: block; */
 		background-color: var(--background-colour-dark);
 	}
 
+	li {
+		margin-top: calc(2 * var(--theme-spacing-base));
+	}
 	li a {
 		font-size: 1rem;
-		margin: 4px calc(var(--theme-spacing-base));
+			calc(var(--theme-spacing-base));
 		font-weight: bold;
-		margin: 0;
+	}
+
+	/* Styling the active part of the path */
+	.active {
+		text-decoration-line: underline;
+		text-decoration-color: var(--background-colour-darker);
+		text-decoration-thickness: var(--theme-spacing-base);
 	}
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import NavBar from "../components/NavBar.astro";
 import Header from "../components/Header.astro";
 import "../styling/variables.css";
+import "../styling/globalStyles.css";
 export interface Props {
 	title?: string;
 	subtitle?: string;
@@ -78,19 +79,4 @@ const formattedTitle = `${title}${subtitle ? ` | ${subtitle}` : ""}`;
 		max-width: 1000px;
 		padding: 1.5rem;
 	}
-	#nav-container {
-		/* flex-grow: 1; */
-	}
-	/* .expanded { */
-	/* 	display: unset; */
-	/* } */
-	/* @media screen and (min-width: 636px) { */
-	/* 	nav { */
-	/* 		margin-left: 5em; */
-	/* 		display: block; */
-	/* 		position: static; */
-	/* 		width: auto; */
-	/* 		background: none; */
-	/* 	} */
-	/* } */
 </style>

--- a/src/pages/events/fieldtrips.astro
+++ b/src/pages/events/fieldtrips.astro
@@ -16,7 +16,7 @@ const renderedEvents = (
 )
 	.filter((e) => e.remarkPluginFrontmatter.type === "Field Trip")
 	.sort((e1, e2) => {
-		return -e1.remarkPluginFrontmatter.startDate.localeCompare(
+		return e1.remarkPluginFrontmatter.startDate.localeCompare(
 			e2.remarkPluginFrontmatter.startDate
 		);
 	});

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -13,7 +13,7 @@ const renderedEvents = (
 		})
 	)
 ).sort((e1, e2) => {
-	return -e1.remarkPluginFrontmatter.startDate.localeCompare(
+	return e1.remarkPluginFrontmatter.startDate.localeCompare(
 		e2.remarkPluginFrontmatter.startDate
 	);
 });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,19 +1,18 @@
 ---
-export const prerender = false;
-
 import Layout from "../layouts/Layout.astro";
 import Card from "../components/Card.astro";
 import Event from "../components/Event.astro";
 
 import { getCollection } from "astro:content";
 
-import { APS_FACEBOOK_LINK, APS_YOUTUBE_LINK } from "../utility";
+import {
+	APS_FACEBOOK_LINK,
+	APS_YOUTUBE_LINK,
+	getTodayString,
+} from "../utility";
 
 // get the next event
-const today = new Date();
-const offset = today.getTimezoneOffset();
-const todayWithOffset = new Date(today.getTime() - offset * 60 * 1000);
-const todayString = todayWithOffset.toISOString().split("T")[0];
+const todayString = getTodayString();
 
 const allEvents = await getCollection("events");
 const renderedEvents = (

--- a/src/styling/globalStyles.css
+++ b/src/styling/globalStyles.css
@@ -1,0 +1,1 @@
+/* Mostly class-based styles which should apply to the whole site */

--- a/src/utility/__tests__/pathMatchesDestination.spec.ts
+++ b/src/utility/__tests__/pathMatchesDestination.spec.ts
@@ -1,5 +1,27 @@
 import { it, expect } from "vitest";
 
-it("should work", () => {
-	expect(true).toBe(true);
-});
+import { pathMatchesDestination } from "../functions";
+
+const cases: Array<{ path: string; destination: string; match: boolean }> = [
+	{ path: "/", destination: "/", match: true },
+	{ path: "/", destination: "/events/", match: false },
+	{ path: "/", destination: "/events", match: false },
+	{ path: "/events", destination: "/events", match: true },
+	{ path: "/events/", destination: "/events", match: true },
+	{ path: "/events", destination: "/events/", match: true },
+	{ path: "/events/", destination: "/events/", match: true },
+	{ path: "/events", destination: "/events/monthlymeetings", match: false },
+	{ path: "/events/monthlymeetings", destination: "/events/", match: true }, // if you are at a subheading you should register as being at the upper part
+	{ path: "/events", destination: "/", match: false },
+	{
+		path: "/events/monthlymeetings",
+		destination: "/events/fieldtrips",
+		match: false,
+	},
+];
+it.each(cases)(
+	"path $path matches destination $destination? $match",
+	({ path, destination, match }) => {
+		expect(pathMatchesDestination(path, destination)).toBe(match);
+	}
+);

--- a/src/utility/functions.ts
+++ b/src/utility/functions.ts
@@ -49,22 +49,40 @@ export const generateEventDateTimeString = (
 };
 
 export const pathMatchesDestination = (path: string, destination: string) => {
-	/* console.log({ path, destination }); */
-	if (path === "") {
-		// we're at the home page
-		/* console.log('Testing agains the home page:', destination === '/') */
-		return destination === "/";
-	}
+	// split into segments
+	const pathSegments = path.split("/").filter((segment) => !!segment);
+	const destinationSegments = destination
+		.split("/")
+		.filter((segment) => !!segment);
 
-	const segments = destination.split("/").filter((elem) => !!elem);
-	/* console.log({ segments }) */
-	const lastSegment = segments.at(-1);
-	/* console.log({ lastSegment, path }) */
-	if (!lastSegment) {
+	// console.log({ pathSegments, destinationSegments });
+
+	if (destinationSegments.length === 0) {
+		return pathSegments.length === 0;
+	}
+	if (destinationSegments.length > pathSegments.length) {
 		return false;
 	}
-	const match = new RegExp(path, "i").test(lastSegment);
-	/* console.log({ match }) */
-	/* console.log() */
-	return match;
+	if (
+		destinationSegments.length <= pathSegments.length &&
+		destinationSegments.every(
+			(destinationSegment, index) =>
+				destinationSegment === pathSegments[index]
+		)
+	) {
+		return true;
+	}
+
+	return false;
+};
+
+/**
+ * Get the YYYY-MM-DD string corresponding to today's date
+ */
+export const getTodayString = () => {
+	const today = new Date();
+	const offset = today.getTimezoneOffset();
+	const todayWithOffset = new Date(today.getTime() - offset * 60 * 1000);
+	const todayString = todayWithOffset.toISOString().split("T")[0];
+	return todayString;
 };

--- a/src/utility/index.ts
+++ b/src/utility/index.ts
@@ -2,6 +2,7 @@ export { APS_YOUTUBE_LINK, APS_FACEBOOK_LINK } from "./constants";
 export {
 	generateEventDateTimeString,
 	pathMatchesDestination,
+	getTodayString,
 } from "./functions";
 export type { LinkInformation } from "./navLinks";
 export { links } from "./navLinks";


### PR DESCRIPTION
Previously, the nav components would only display an exact match. Now, they display a match if the destination of the nav component is a subset of the current path. For instance, if you are at
/events/monthlymeetings, both the components to /events and /events/monthlymeetings are styled as active.

Closes #22