### PR TITLE
feat: added ability to have announcements

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -188,7 +188,23 @@ declare module 'astro:content' {
 	>;
 
 	type ContentEntryMap = {
-		"disclaimers": {
+		"announcements": {
+"2023-09-symposium-announcement.md": {
+	id: "2023-09-symposium-announcement.md";
+  slug: "2023-09-symposium-announcement";
+  body: string;
+  collection: "announcements";
+  data: InferEntrySchema<"announcements">
+} & { render(): Render[".md"] };
+"2023-fossil-sorting.md": {
+	id: "2023-fossil-sorting.md";
+  slug: "2023-fossil-sorting";
+  body: string;
+  collection: "announcements";
+  data: InferEntrySchema<"announcements">
+} & { render(): Render[".md"] };
+};
+"disclaimers": {
 "contactUs.md": {
 	id: "contactUs.md";
   slug: "contactus";

--- a/src/components/Announcement.astro
+++ b/src/components/Announcement.astro
@@ -1,0 +1,64 @@
+---
+import { generateEventDateTimeString } from "../utility";
+import type { AnnouncementFrontmatter } from "../content/config";
+interface Props {
+	frontmatter: AnnouncementFrontmatter;
+	last: boolean;
+}
+const { frontmatter, last } = Astro.props;
+const { title, startDate, endDate } = frontmatter;
+const eventDateTimeString = generateEventDateTimeString(
+	startDate,
+	undefined,
+	endDate,
+	undefined
+);
+
+const containerClassList = ["container"];
+---
+
+<section
+	class:list={last ? [] : ["not-last"]}
+	data-startdate={startDate}
+	data-enddate={endDate ? endDate : startDate}
+	data-type="announcement"
+>
+	<h3 class="event-title">{title}</h3>
+	<p class="event-time">
+		{eventDateTimeString}
+	</p>
+	<div class:list={containerClassList}>
+		<div class="content-container">
+			<slot />
+		</div>
+	</div>
+</section>
+
+<style>
+	section.not-last {
+		margin: 3px 0px;
+		margin-bottom: 8px;
+		border-bottom: solid 1px black;
+	}
+	p.event-type {
+		color: var(--accent-colour-dark);
+		margin-bottom: 0px;
+		font-size: 0.75rem;
+	}
+	.event-title {
+		margin-top: var(--theme-spacing-base);
+		margin-bottom: calc(var(--theme-spacing-base));
+	}
+	.event-time {
+		color: var(--accent-colour-medium);
+		font-size: 1rem;
+		margin: var(--theme-spacing-base) 0;
+	}
+
+	/* Desktop settings */
+	@media screen and (min-width: 768px) {
+		.container.image-present {
+			flex-direction: row;
+		}
+	}
+</style>

--- a/src/content/announcements/2023-09-symposium-announcement.md
+++ b/src/content/announcements/2023-09-symposium-announcement.md
@@ -1,0 +1,7 @@
+---
+title: Paleo Symposium 2024 Dates!
+startDate: "2023-08-25"
+endDate: "2023-09-30"
+---
+
+The dates for the 27<sup>th</sup> annual Alberta Palaeontological Society Symposium have been anounced! The symposium will take place on Saturday, March 16 - Sunday, March 17. See the [symposium page](/events/symposium/) for more information.

--- a/src/content/announcements/2023-fossil-sorting.md
+++ b/src/content/announcements/2023-fossil-sorting.md
@@ -1,0 +1,9 @@
+---
+title: Fossil Sorting Opportunity
+startDate: "2023-08-25"
+endDate: "2023-10-15"
+---
+
+This November and December we will once again to sorting fossils for Dr. Jessica Theodor and Dr. Alex Dutchak from the University of Calgary. This is open to anyone and no previous experience is necessary. It's a great family event!
+
+For more information, see the [events](/events/) page.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -83,10 +83,22 @@ const faqsCollection = defineCollection({
 	schema: faqsSchema,
 });
 
+const announcementSchema = z.object({
+	title: z.string(),
+	startDate: z.string(),
+	endDate: z.string(),
+});
+const announcementCollection = defineCollection({
+	type: "content",
+	schema: announcementSchema,
+});
+export type AnnouncementFrontmatter = z.infer<typeof announcementSchema>;
+
 export const collections = {
 	events: eventCollection,
 	disclaimers: disclaimersCollection,
 	bulletins: bulletinsCollection,
 	bulletinVolumes: bulletinVolumesCollection,
 	faqs: faqsCollection,
+	announcements: announcementCollection,
 };

--- a/src/content/events/2024-03-16-paleoSymposium1.md
+++ b/src/content/events/2024-03-16-paleoSymposium1.md
@@ -20,6 +20,8 @@ virtually. Families are encouraged to bring fossils to our
 identification booth where APS members will do their best to provide you
 with information.
 
+The first day will include lectures by notable paleontologists, an opportunity to have APS members identify your fossils, and a host of other events! Stay tuned for additional inforamtion.
+
 See the [symposium page](/events/symposium) for additional details.
 
 View a <a href="https://youtu.be/neXG3Y0q-O8">brief video</a> of the 2018

--- a/src/content/events/2024-03-17-paleoSymposium2.md
+++ b/src/content/events/2024-03-17-paleoSymposium2.md
@@ -20,6 +20,8 @@ virtually. Families are encouraged to bring fossils to our
 identification booth where APS members will do their best to provide you
 with information.
 
+This second day will feature workshops on topics related to palaeontology in Alberta. Stay tuned for more information!
+
 See the [symposium page](/events/symposium) for additional details.
 
 View a <a href="https://youtu.be/neXG3Y0q-O8">brief video</a> of the 2018

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import Card from "../components/Card.astro";
 import Event from "../components/Event.astro";
+import Announcement from "../components/Announcement.astro";
 
 import { getCollection } from "astro:content";
 
@@ -9,6 +10,7 @@ import {
 	APS_FACEBOOK_LINK,
 	APS_YOUTUBE_LINK,
 	getTodayString,
+	formatDate,
 } from "../utility";
 
 // get the next event
@@ -35,6 +37,35 @@ let nextEvent;
 if (renderedEvents.length > 0) {
 	nextEvent = renderedEvents[renderedEvents.length - 1];
 }
+
+const allAnnouncements = (await getCollection("announcements"))
+	.filter(({ data }) => {
+		// NB This is horrifying. There definitely needs to be a better way of doing this
+		// TODO sort out this nonsense
+		let [year, month, day] = getTodayString().split("-");
+		day = Number(day) + 2;
+		const today = new Date([year, month, day].join("-"));
+		const startDate = new Date(data.startDate);
+		const endDate = new Date(data.endDate);
+		console.log({
+			today,
+			startDate,
+			endDate,
+			/* today2, today3 */
+		});
+		return today >= startDate && today <= endDate;
+	})
+	.sort((a1, a2) => {
+		return (
+			new Date(a1.data.startDate).getTime() -
+			new Date(a2.data.startDate).getTime()
+		);
+	});
+const renderedAnnouncements = await Promise.all(
+	allAnnouncements.map(async (announcement) => {
+		return await announcement.render();
+	})
+);
 ---
 
 <Layout title="Alberta Palaeontological Society">
@@ -68,6 +99,28 @@ if (renderedEvents.length > 0) {
 			wonders of palaeontology, ensuring that people of all ages can
 			explore and appreciate the fascinating world of prehistoric life.
 		</p>
+		{
+			renderedAnnouncements.length > 0 ? (
+				<section>
+					<h2>Announcements</h2>
+					{renderedAnnouncements.map(
+						(announcement, index, allAnnouncements) => {
+							const { Content, headings } = announcement;
+							return (
+								<Announcement
+									frontmatter={
+										announcement.remarkPluginFrontmatter
+									}
+									last={index === allAnnouncements.length - 1}
+								>
+									<Content />
+								</Announcement>
+							);
+						}
+					)}
+				</section>
+			) : null
+		}
 	</section>
 	{
 		nextEvent && (

--- a/src/utility/functions.ts
+++ b/src/utility/functions.ts
@@ -93,3 +93,21 @@ export const getTodayString = () => {
 	const todayString = todayWithOffset.toISOString().split("T")[0];
 	return todayString;
 };
+
+// https://stackoverflow.com/questions/23593052/format-javascript-date-as-yyyy-mm-dd
+export const formatDate = (date?: string) => {
+	let d: Date;
+	if (date) {
+		d = new Date(date);
+	} else {
+		d = new Date();
+	}
+	let month = "" + (d.getMonth() + 1);
+	let day = "" + d.getDate();
+	const year = d.getFullYear();
+
+	if (month.length < 2) month = "0" + month;
+	if (day.length < 2) day = "0" + day;
+
+	return [year, month, day].join("-");
+};

--- a/src/utility/index.ts
+++ b/src/utility/index.ts
@@ -3,6 +3,7 @@ export {
 	generateEventDateTimeString,
 	pathMatchesDestination,
 	getTodayString,
+	formatDate,
 } from "./functions";
 export type { LinkInformation } from "./navLinks";
 export { links } from "./navLinks";


### PR DESCRIPTION
Added another collection, this time for temporary announcements. An announcement has a start date (first day to start showing it) and an end date (last day to show it). Any relevant announcements will be rendered on the homepage.

Also added in announcements about the fossil sorting and symposium.

Closes #61