### PR TITLE
fix: changelog ignore when formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 .github/
+CHANGELOG.md


### PR DESCRIPTION
Prettier now ignores the changelog when formatting (so every PR won't have a spurious commit which just formats the readme).

Closes #90