### PR TITLE
fix: updated fossil sorting announcements to include minimum age

### DIFF
--- a/src/content/events/2023-11-26-fossilSorting2.md
+++ b/src/content/events/2023-11-26-fossilSorting2.md
@@ -15,6 +15,8 @@ No fee for this event. It is open to the public and it is a good family event.
 
 Registration is not required, but if you contact me, Mona Trick, (587) 578-4579 or email giftshop@albertapaleo.org, and let me know if you are planning to attend, then I’ll be able to inform you in case we need to cancel a session. No experience is required. Bring tweezers to pick the tiny fossils from the soil and a pen to label your finds.
 
+Due to the use of microscopes and the delicate nature of the fossils we’re collecting, there is a minimum age of 12 for all participants.
+
 ### Dates:
 
 -   Sunday November 5

--- a/src/content/events/2023-12-08-monthlyMeeting.md
+++ b/src/content/events/2023-12-08-monthlyMeeting.md
@@ -10,4 +10,4 @@ The Alberta Palaeontological Society welcomes CSPG (CEGA) members, families and 
 
 The evening will start with a potluck dinner at 7:30 PM followed by a social evening. Bring your fossils from your summer field trips! APS members will have specimens on display and resident experts will be on hand to help identify fossils that are brought in.
 
-**Please note that this meeting is on the 2nd friday of the month rather then the usual 3rd friday of the month.**
+**Please note that this meeting is on the 2nd Friday of the month rather then the usual 3rd Friday of the month.**

--- a/src/content/events/2023-12-10-fossilSorting3.md
+++ b/src/content/events/2023-12-10-fossilSorting3.md
@@ -15,6 +15,8 @@ No fee for this event. It is open to the public and it is a good family event.
 
 Registration is not required, but if you contact me, Mona Trick, (587) 578-4579 or email giftshop@albertapaleo.org, and let me know if you are planning to attend, then I’ll be able to inform you in case we need to cancel a session. No experience is required. Bring tweezers to pick the tiny fossils from the soil and a pen to label your finds.
 
+Due to the use of microscopes and the delicate nature of the fossils we’re collecting, there is a minimum age of 12 for all participants.
+
 ### Dates:
 
 -   Sunday November 5

--- a/src/content/events/2024-01-14-fossilSorting1.md
+++ b/src/content/events/2024-01-14-fossilSorting1.md
@@ -25,6 +25,8 @@ you if we need to cancel this session. No experience is required. Bring tweezers
 pointed ends) or a small paint brush to pick the tiny fossils from the soil and a pen to
 label your finds. Parking is free at Mount Royal University on Sundays.
 
+Due to the use of microscopes and the delicate nature of the fossils we’re collecting, there is a minimum age of 12 for all participants.
+
 <figure>
 <img style="width: 80%;" src="/events/20231105_fossilSorting.jpg" />
 <figcaption>Under the guidance of Dr. Alex Dutchak (shown lower right), volunteers search

--- a/src/content/events/2024-01-28-fossilSorting2.md
+++ b/src/content/events/2024-01-28-fossilSorting2.md
@@ -25,6 +25,8 @@ you if we need to cancel this session. No experience is required. Bring tweezers
 pointed ends) or a small paint brush to pick the tiny fossils from the soil and a pen to
 label your finds. Parking is free at Mount Royal University on Sundays.
 
+Due to the use of microscopes and the delicate nature of the fossils we’re collecting, there is a minimum age of 12 for all participants.
+
 <figure>
 <img style="width: 80%;" src="/events/20231105_fossilSorting.jpg" />
 <figcaption>Under the guidance of Dr. Alex Dutchak (shown lower right), volunteers search

--- a/src/content/events/2024-02-11-fossilSorting3.md
+++ b/src/content/events/2024-02-11-fossilSorting3.md
@@ -25,6 +25,8 @@ you if we need to cancel this session. No experience is required. Bring tweezers
 pointed ends) or a small paint brush to pick the tiny fossils from the soil and a pen to
 label your finds. Parking is free at Mount Royal University on Sundays.
 
+Due to the use of microscopes and the delicate nature of the fossils we’re collecting, there is a minimum age of 12 for all participants.
+
 <figure>
 <img style="width: 80%;" src="/events/20231105_fossilSorting.jpg" />
 <figcaption>Under the guidance of Dr. Alex Dutchak (shown lower right), volunteers search

--- a/src/content/events/2024-02-25-fossilSorting4.md
+++ b/src/content/events/2024-02-25-fossilSorting4.md
@@ -25,6 +25,8 @@ you if we need to cancel this session. No experience is required. Bring tweezers
 pointed ends) or a small paint brush to pick the tiny fossils from the soil and a pen to
 label your finds. Parking is free at Mount Royal University on Sundays.
 
+Due to the use of microscopes and the delicate nature of the fossils we’re collecting, there is a minimum age of 12 for all participants.
+
 <figure>
 <img style="width: 80%;" src="/events/20231105_fossilSorting.jpg" />
 <figcaption>Under the guidance of Dr. Alex Dutchak (shown lower right), volunteers search

--- a/src/content/events/2024-03-10-fossilSorting5.md
+++ b/src/content/events/2024-03-10-fossilSorting5.md
@@ -25,6 +25,8 @@ you if we need to cancel this session. No experience is required. Bring tweezers
 pointed ends) or a small paint brush to pick the tiny fossils from the soil and a pen to
 label your finds. Parking is free at Mount Royal University on Sundays.
 
+Due to the use of microscopes and the delicate nature of the fossils we’re collecting, there is a minimum age of 12 for all participants.
+
 <figure>
 <img style="width: 80%;" src="/events/20231105_fossilSorting.jpg" />
 <figcaption>Under the guidance of Dr. Alex Dutchak (shown lower right), volunteers search


### PR DESCRIPTION
It is now clear that there is a minimum age of 12 for the fossil sorting sessions.

Closes #115