### PR TITLE
fix: added september 2024 date

### DIFF
--- a/src/content/events/2024-09-20-monthlyMeeting.md
+++ b/src/content/events/2024-09-20-monthlyMeeting.md
@@ -1,6 +1,6 @@
 ---
 title: 'Monthly Meeting: September 2024'
-startDate: '2023-09-20'
+startDate: '2024-09-20'
 startTime: '7:30 PM'
 endTime: '9 PM'
 type: 'Monthly Meeting'


### PR DESCRIPTION
The Sepember 2024 meeting event had the wrong year (2023), meaning it wasn't showing up! This fixes that.

Closes #119