### PR TITLE
feat: removed development from flow

### DIFF
--- a/.github/workflows/semanticVersioning.yml
+++ b/.github/workflows/semanticVersioning.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - "development"
+      - "main"
     paths-ignore:
       - CHANGELOG.md
 
@@ -19,7 +19,7 @@ jobs:
           node-version: "16"
       - name: Update version
         run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           npx standard-version
       - name: Push changes


### PR DESCRIPTION
Changed the GH actions so now everything happens on main; means that the development branch is largely deprecated. This was done to simplify the process of making changes, especially because I am the only one working on this and staging versions are created automatically by netlify on PR.

Closes #135