### PR TITLE
fix: minor wording change on the symposium page

### DIFF
--- a/src/pages/events/symposium.astro
+++ b/src/pages/events/symposium.astro
@@ -160,7 +160,7 @@ import EmailLink from '../../components/EmailLink.astro'
 			>.
 		</p>
 
-		<p>In addition to presenting the poster, abstracts of all of the posters will be gathered into a Abstracts Volume. When preparing your poster, please also send the abstract to Howard Allen for inclusion in this collection. For more information, please <a href="/symposium/2024/Abstract Guidelines 2024.pdf">see the following document.</a></p>
+		<p>In addition to presenting the poster, abstracts of all of the posters will be gathered into a Abstracts Volume. When preparing your poster, please also send the abstract to Howard Allen for inclusion in this collection. For more information, please <a href="/symposium/2024/Abstract Guidelines 2024.pdf">see the Guidelines for Authors.</a></p>
 
 		<p>
 			All posters should be submitted to our poster coordinator, Matthew


### PR DESCRIPTION
Made a minor wording change ont he symposium page to make it more clear that the document is the Guideline for Authors.

Closes #152