### PR TITLE
feat: announcement and page changes for paleo 2024

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -231,6 +231,13 @@ declare module 'astro:content' {
   collection: "announcements";
   data: InferEntrySchema<"announcements">
 } & { render(): Render[".md"] };
+"2024-05-paleo-2024-announcement.md": {
+	id: "2024-05-paleo-2024-announcement.md";
+  slug: "2024-05-paleo-2024-announcement";
+  body: string;
+  collection: "announcements";
+  data: InferEntrySchema<"announcements">
+} & { render(): Render[".md"] };
 };
 "disclaimers": {
 "contactUs.md": {

--- a/src/content/announcements/2024-05-paleo-2024-announcement.md
+++ b/src/content/announcements/2024-05-paleo-2024-announcement.md
@@ -1,0 +1,11 @@
+---
+title: Paleo 2024 Videos Available!
+startDate: '2024-04-15'
+endDate: '2024-06-01'
+---
+
+<div style="display: flex; flex-direction: row; align-items: center; justify-content: center;">
+<img src="/events/paleo2024/auditorium.png" alt="A view of the auditorium at Paleo 2024" style="width: 80%;" />
+</div>
+
+The recordings for a selection of the talks at [Paleo 2024](/events/symposium) are now available on a [playlist on our YouTube channel!](https://www.youtube.com/playlist?list=PLIbLEoMjr_5NJoPQJpN-0VJPJ-xDXMrxO) Thanks to the presenters for making this such a wonderful event and allowing us to share these with the world.

--- a/src/pages/events/symposium.astro
+++ b/src/pages/events/symposium.astro
@@ -13,163 +13,13 @@ import EmailLink from '../../components/EmailLink.astro'
 
 	<h2>Paleo 2024 - APS Symposium 2024</h2>
 
-	<p>
-		In conjunction with Mount Royal University Earth and Environmental
-		Sciences and the CEGA Paleontology Division, we are pleased to announce
-		that the 27<sup>th</sup> annual Alberta Palaeontological Society Symposium
-		will take place on Saturday, March 16, 2024 from 9:00AM - 4:30PM.
-	</p>
+	<p>This event is done for this year! You can find a playlist with a selection of recorded talks at <a href="https://www.youtube.com/playlist?list=PLIbLEoMjr_5NJoPQJpN-0VJPJ-xDXMrxO">the Paleo 2024 playlist on our YouTube channel</a> or you can view a selection of talks from the 2023 symposium at the<a 
+			href="https://www.youtube.com/playlist?list=PLIbLEoMjr_5N6TiqYkZwFSTqoHC13T-WT" 
+ 	> 
+	Paleo 2023 playlist
+ 	</a>.</p>
 
-	<p>
-		This symposium will contain presentations from a mix of amateur and
-		professional palaeontologists. The aim is to showcase palaeontology to
-		the general public and to provide an opportunity for contact between the
-		Alberta Palaeontological Society, industry, government and educational
-		facilities. The event is free and all are welcome to attend or join
-		virtually. Families are encouraged to bring fossils to our
-		identification booth where APS members will do their best to provide you
-		with information.
-	</p>
-
-	<p>
-		You can view a <a
-			href="https://www.youtube.com/playlist?list=PLIbLEoMjr_5N6TiqYkZwFSTqoHC13T-WT"
-		>
-			selection of talks from the 2023 symposium
-		</a> on our <a href="https://www.youtube.com/@AlbertaPaleo">
-			YouTube channel
-		</a>.
-	</p>
-
-	For additional information, see <a
-		href="/symposium/2024/Paleo2024Circular1MDT.pdf">circular 1</a
-	> or <a href="/symposium/2024/Paleo2024Circular2.pdf">circular 2</a>
-
-	<h3>Schedule</h3>
-	<section class="schedule">
-		<table>
-			<tbody>
-				<tr>
-					<td> 9:00 - 9:15 am</td>
-					<td>
-						Opening Statements <br />
-						<emph> Cory Gross, APS President Symposium</emph>
-						<br />
-						Introduction <br />
-						<emph> Lacey Holoboff, APS Programs Coordinator</emph>
-					</td>
-				</tr>
-			</tbody>
-			<tr>
-				<td>9:15 – 9:50 am</td>
-				<td>
-					The Messel Pit, central Germany &ndash; Fossilized treasures
-					of the Eocene.<br />
-					<emph>Tako Koning, Consulting Geologist</emph>
-				</td>
-			</tr>
-			<tr>
-				<td>9:55 – 10:30 am</td>
-				<td
-					>Palaeontology of the Springbank Off-stream Reservoir
-					Project: The Alberta Heritage Act at work. <br />
-					<emph> Dr Jon Noad, Stantec Consulting</emph>
-				</td>
-			</tr>
-			<tr> <td>10:30 – 10:45 am</td> <td>Coffee Break</td></tr>
-			<tr>
-				<td>10:45 – 11:20 am</td>
-				<td
-					>The Problem of Protoceratids &ndash; the first horned
-					artiodactyls. <br />
-					<emph>Dr Jessica Theodor, University of Calgary</emph></td
-				>
-			</tr>
-			<tr>
-				<td>11:25 – 12:00 pm</td>
-				<td
-					>Lizard brain or bird brained? New insight into the
-					evolution of the theropod brain.<br /><emph
-						>Jared Voris, University of Calgary</emph
-					>
-				</td>
-			</tr>
-			<tr>
-				<td>12:00 – 1:00 pm</td>
-				<td>Lunch Break &amp; Poster Displays</td></tr
-			>
-			<tr>
-				<td>1:00 – 1:45 pm</td>
-				<td
-					>Ichnodiversity and taphonomy of continental bioerosion
-					traces on Triceratops bones from the Frenchman Formation of
-					Saskatchewan. <br /><emph
-						>Jack Milligan, University of Saskatchewan</emph
-					>
-				</td>
-			</tr>
-			<tr>
-				<td>1:45 – 2:45 pm</td>
-				<td
-					>Poster presentations breakout session &amp; coffee break. <br
-					/>
-					Poster presenters are requested to be with their posters.
-				</td>
-			</tr>
-			<tr>
-				<td>2:45 – 3:15 pm</td><td
-					>Update on the Kaskie Hadrosaur fieldwork. <br />
-					<emph>
-						Darren Tanke, Royal Tyrrell Museum of Palaeontology
-					</emph>
-				</td>
-			</tr>
-			<tr>
-				<td>3:15 – 3:30 pm</td>
-				<td>Coffee break.</td>
-			</tr>
-			<tr>
-				<td>3:30 – 4:15 pm</td>
-				<td
-					>Stratigraphy and fossil sites. <br /><emph
-						>Dr Jenni Scott, Mount Royal University</emph
-					></td
-				>
-			</tr>
-			<tr>
-				<td>4:15 – 4:30 pm</td>
-				<td
-					>Closing remarks for Paleo 2024.<br />
-					<emph>Lacey Holoboff, APS Programs Coordinator</emph></td
-				>
-			</tr>
-		</table>
-	</section>
-
-	<h3>Posters</h3>
-
-	<section>
-		<p>
-			The APS invites you to submit a poster for the symposium! If you are
-			an avocational or professional palaeontologist and have been doing
-			research, we would love for you to submit your poster for the
-			symposium. Any area related to palaeontology is suitable. For
-			additional information, including information about the format and
-			how to create it, please see <a
-				href="/symposium/2024/Paleo2024Circular1MDT.pdf">circular 1</a
-			>.
-		</p>
-
-		<p>In addition to presenting the poster, abstracts of all of the posters will be gathered into a Abstracts Volume. When preparing your poster, please also send the abstract to Howard Allen for inclusion in this collection. For more information, please <a href="/symposium/2024/Abstract Guidelines 2024.pdf">see the Guidelines for Authors.</a> The deadline for submitting the abstract is February 15th.</p>
-
-		<p>
-			All posters should be submitted to our poster coordinator, Matthew
-			Rhodes, at <EmailLink
-				email="posters@albertapaleo.org"
-				subject="Paleo 2024 Poster Submission"
-			/>. The deadline for submission is February 15, 2024.
-		</p>
-	</section>
+	<p>Thanks to everyone, epecially the speakers, who made this event possible!</p>
 </Layout>
 
 <style>
@@ -196,3 +46,162 @@ import EmailLink from '../../components/EmailLink.astro'
 		font-weight: bold;
 	}
 </style>
+
+
+	/* <p> */
+	/* 	In conjunction with Mount Royal University Earth and Environmental */
+	/* 	Sciences and the CEGA Paleontology Division, we are pleased to announce */
+	/* 	that the 27<sup>th</sup> annual Alberta Palaeontological Society Symposium */
+	/* 	will take place on Saturday, March 16, 2024 from 9:00AM - 4:30PM. */
+	/* </p> */
+
+	/* <p> */
+	/* 	This symposium will contain presentations from a mix of amateur and */
+	/* 	professional palaeontologists. The aim is to showcase palaeontology to */
+	/* 	the general public and to provide an opportunity for contact between the */
+	/* 	Alberta Palaeontological Society, industry, government and educational */
+	/* 	facilities. The event is free and all are welcome to attend or join */
+	/* 	virtually. Families are encouraged to bring fossils to our */
+	/* 	identification booth where APS members will do their best to provide you */
+	/* 	with information. */
+	/* </p> */
+
+	/* <p> */
+	/* 	You can view a <a */
+	/* 		href="https://www.youtube.com/playlist?list=PLIbLEoMjr_5N6TiqYkZwFSTqoHC13T-WT" */
+	/* 	> */
+	/* 		selection of talks from the 2023 symposium */
+	/* 	</a> on our <a href="https://www.youtube.com/@AlbertaPaleo"> */
+	/* 		YouTube channel */
+	/* 	</a>. */
+	/* </p> */
+
+	/* For additional information, see <a */
+	/* 	href="/symposium/2024/Paleo2024Circular1MDT.pdf">circular 1</a */
+	/* > or <a href="/symposium/2024/Paleo2024Circular2.pdf">circular 2</a> */
+
+	/* <h3>Schedule</h3> */
+	/* <section class="schedule"> */
+	/* 	<table> */
+	/* 		<tbody> */
+	/* 			<tr> */
+	/* 				<td> 9:00 - 9:15 am</td> */
+	/* 				<td> */
+	/* 					Opening Statements <br /> */
+	/* 					<emph> Cory Gross, APS President Symposium</emph> */
+	/* 					<br /> */
+	/* 					Introduction <br /> */
+	/* 					<emph> Lacey Holoboff, APS Programs Coordinator</emph> */
+	/* 				</td> */
+	/* 			</tr> */
+	/* 		</tbody> */
+	/* 		<tr> */
+	/* 			<td>9:15 – 9:50 am</td> */
+	/* 			<td> */
+	/* 				The Messel Pit, central Germany &ndash; Fossilized treasures */
+	/* 				of the Eocene.<br /> */
+	/* 				<emph>Tako Koning, Consulting Geologist</emph> */
+	/* 			</td> */
+	/* 		</tr> */
+	/* 		<tr> */
+	/* 			<td>9:55 – 10:30 am</td> */
+	/* 			<td */
+	/* 				>Palaeontology of the Springbank Off-stream Reservoir */
+	/* 				Project: The Alberta Heritage Act at work. <br /> */
+	/* 				<emph> Dr Jon Noad, Stantec Consulting</emph> */
+	/* 			</td> */
+	/* 		</tr> */
+	/* 		<tr> <td>10:30 – 10:45 am</td> <td>Coffee Break</td></tr> */
+	/* 		<tr> */
+	/* 			<td>10:45 – 11:20 am</td> */
+	/* 			<td */
+	/* 				>The Problem of Protoceratids &ndash; the first horned */
+	/* 				artiodactyls. <br /> */
+	/* 				<emph>Dr Jessica Theodor, University of Calgary</emph></td */
+	/* 			> */
+	/* 		</tr> */
+	/* 		<tr> */
+	/* 			<td>11:25 – 12:00 pm</td> */
+	/* 			<td */
+	/* 				>Lizard brain or bird brained? New insight into the */
+	/* 				evolution of the theropod brain.<br /><emph */
+	/* 					>Jared Voris, University of Calgary</emph */
+	/* 				> */
+	/* 			</td> */
+	/* 		</tr> */
+	/* 		<tr> */
+	/* 			<td>12:00 – 1:00 pm</td> */
+	/* 			<td>Lunch Break &amp; Poster Displays</td></tr */
+	/* 		> */
+	/* 		<tr> */
+	/* 			<td>1:00 – 1:45 pm</td> */
+	/* 			<td */
+	/* 				>Ichnodiversity and taphonomy of continental bioerosion */
+	/* 				traces on Triceratops bones from the Frenchman Formation of */
+	/* 				Saskatchewan. <br /><emph */
+	/* 					>Jack Milligan, University of Saskatchewan</emph */
+	/* 				> */
+	/* 			</td> */
+	/* 		</tr> */
+	/* 		<tr> */
+	/* 			<td>1:45 – 2:45 pm</td> */
+	/* 			<td */
+	/* 				>Poster presentations breakout session &amp; coffee break. <br */
+	/* 				/> */
+	/* 				Poster presenters are requested to be with their posters. */
+	/* 			</td> */
+	/* 		</tr> */
+	/* 		<tr> */
+	/* 			<td>2:45 – 3:15 pm</td><td */
+	/* 				>Update on the Kaskie Hadrosaur fieldwork. <br /> */
+	/* 				<emph> */
+	/* 					Darren Tanke, Royal Tyrrell Museum of Palaeontology */
+	/* 				</emph> */
+	/* 			</td> */
+	/* 		</tr> */
+	/* 		<tr> */
+	/* 			<td>3:15 – 3:30 pm</td> */
+	/* 			<td>Coffee break.</td> */
+	/* 		</tr> */
+	/* 		<tr> */
+	/* 			<td>3:30 – 4:15 pm</td> */
+	/* 			<td */
+	/* 				>Stratigraphy and fossil sites. <br /><emph */
+	/* 					>Dr Jenni Scott, Mount Royal University</emph */
+	/* 				></td */
+	/* 			> */
+	/* 		</tr> */
+	/* 		<tr> */
+	/* 			<td>4:15 – 4:30 pm</td> */
+	/* 			<td */
+	/* 				>Closing remarks for Paleo 2024.<br /> */
+	/* 				<emph>Lacey Holoboff, APS Programs Coordinator</emph></td */
+	/* 			> */
+	/* 		</tr> */
+	/* 	</table> */
+	/* </section> */
+
+	/* <h3>Posters</h3> */
+
+	/* <section> */
+	/* 	<p> */
+	/* 		The APS invites you to submit a poster for the symposium! If you are */
+	/* 		an avocational or professional palaeontologist and have been doing */
+	/* 		research, we would love for you to submit your poster for the */
+	/* 		symposium. Any area related to palaeontology is suitable. For */
+	/* 		additional information, including information about the format and */
+	/* 		how to create it, please see <a */
+	/* 			href="/symposium/2024/Paleo2024Circular1MDT.pdf">circular 1</a */
+	/* 		>. */
+	/* 	</p> */
+
+	/* 	<p>In addition to presenting the poster, abstracts of all of the posters will be gathered into a Abstracts Volume. When preparing your poster, please also send the abstract to Howard Allen for inclusion in this collection. For more information, please <a href="/symposium/2024/Abstract Guidelines 2024.pdf">see the Guidelines for Authors.</a> The deadline for submitting the abstract is February 15th.</p> */
+
+	/* 	<p> */
+	/* 		All posters should be submitted to our poster coordinator, Matthew */
+	/* 		Rhodes, at <EmailLink */
+	/* 			email="posters@albertapaleo.org" */
+	/* 			subject="Paleo 2024 Poster Submission" */
+	/* 		/>. The deadline for submission is February 15, 2024. */
+	/* 	</p> */
+	/* </section> */


### PR DESCRIPTION
Now that the event is over, there is an announcement about the videos being uploaded to the YouTube channel. In addition, most of the content from the event page has been removed (since it's no longer necessary) and a link to the playlists is there instead.

Closes #164